### PR TITLE
Rename CHAT_GPT_API_KEY to OPENAI_API_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ My first ever terminal UI! Everything is stored locally on sqlite and written in
 
 ## Installation
 
-Please make sure that you expose a `CHAT_GPT_API_KEY` inside of your environment; we require it to make api calls!
+Please make sure that you expose a `OPENAI_API_KEY` inside of your environment; we require it to make api calls!
 
 Set up your [api key](https://platform.openai.com/api-keys)
 
 ```bash
-export CHAT_GPT_API_KEY="some-key" # you would want to export this in your .zshrc
+export OPENAI_API_KEY="some-key" # you would want to export this in your .zshrc
 brew tap tearingitup786/tearingitup786
 brew install chatgpt-tui
 chatgpt-tui

--- a/main.go
+++ b/main.go
@@ -379,10 +379,10 @@ func main() {
 	}
 	defer f.Close()
 
-	apiKey := os.Getenv("CHAT_GPT_API_KEY")
+	apiKey := os.Getenv("OPENAI_API_KEY")
 	if "" == apiKey {
-		fmt.Println("CHAT_GPT_API_KEY not set; set it in your profile")
-		fmt.Printf("export CHAT_GPT_API_KEY=your_key in the config for :%v \n", os.Getenv("SHELL"))
+		fmt.Println("OPENAI_API_KEY not set; set it in your profile")
+		fmt.Printf("export OPENAI_API_KEY=your_key in the config for :%v \n", os.Getenv("SHELL"))
 		fmt.Println("Exiting...")
 		os.Exit(1)
 	}

--- a/sessions/message-stream.go
+++ b/sessions/message-stream.go
@@ -84,7 +84,7 @@ func (m Model) constructJsonBody() ([]byte, error) {
 }
 
 func (m *Model) CallChatGpt(resultChan chan ProcessResult) tea.Cmd {
-	apiKey := os.Getenv("CHAT_GPT_API_KEY")
+	apiKey := os.Getenv("OPENAI_API_KEY")
 	processResultID := 0 // Initialize a counter for ProcessResult IDs
 
 	return func() tea.Msg {


### PR DESCRIPTION
For almost all of the apps I use and build make use of the `OPENAI_API_KEY` variable name. This PR renames `CHAT_GPT_API_KEY` to bring it in line with this pseudo standard. It makes managing env secrets much easier IMO.