### PR TITLE
chore: rename go module to nekot

### DIFF
--- a/.goreleaser-rc.yaml
+++ b/.goreleaser-rc.yaml
@@ -1,5 +1,5 @@
 builds:
-  - id: darwin-amd64-chatgpt-tui
+  - id: darwin-amd64-rc-chatgpt-tui
     main: ./
     goos:
       - darwin
@@ -7,17 +7,17 @@ builds:
       - amd64
       - arm64
     env:
-      - pkg_config_sysroot_dir=/sysroot/macos/amd64
-      - pkg_config_path=/sysroot/macos/amd64/usr/local/lib/pkgconfig
-      - cc=o64-clang
-      - cxx=o64-clang++
+      - PKG_CONFIG_SYSROOT_DIR=/sysroot/macos/amd64
+      - PKG_CONFIG_PATH=/sysroot/macos/amd64/usr/local/lib/pkgconfig
+      - CC=o64-clang
+      - CXX=o64-clang++
     flags:
       - -mod=readonly
     ldflags:
-      - -s -w -x main.version={{.version}}
+      - -s -w -X main.version={{.Version}}
     binary: bin/rc-chatgpt-tui
     
-  - id: darwin-amd64-nekot
+  - id: darwin-amd64-rc-nekot
     main: ./
     goos:
       - darwin
@@ -25,28 +25,28 @@ builds:
       - amd64
       - arm64
     env:
-      - pkg_config_sysroot_dir=/sysroot/macos/amd64
-      - pkg_config_path=/sysroot/macos/amd64/usr/local/lib/pkgconfig
-      - cc=o64-clang
-      - cxx=o64-clang++
+      - PKG_CONFIG_SYSROOT_DIR=/sysroot/macos/amd64
+      - PKG_CONFIG_PATH=/sysroot/macos/amd64/usr/local/lib/pkgconfig
+      - CC=o64-clang
+      - CXX=o64-clang++
     flags:
       - -mod=readonly
     ldflags:
-      - -s -w -x main.version={{.version}}
+      - -s -w -X main.version={{.Version}}
     binary: bin/rc-nekot
 
 archives:
-  - id: rc-nekot
+  - id: rc-chatgpt-tui
     builds:
-      - darwin-amd64
+      - darwin-amd64-rc-chatgpt-tui
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     format: zip
     wrap_in_directory: true
 
-  - id: rc-chatgpt-tui
+  - id: rc-nekot
     builds:
-      - darwin-amd64
-    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+      - darwin-amd64-rc-nekot
+    name_template: "rc-nekot_{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     format: zip
     wrap_in_directory: true
 
@@ -75,7 +75,6 @@ brews:
     homepage: https://github.com/tearingItUp786/chatgpt-tui
     commit_author:
       name: tearingitup786
-
     # Setting this will prevent goreleaser to actually try to commit the updated
     # formula - instead, the formula file will be stored on the dist folder only,
     # leaving the responsibility of publishing it to the user.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# ChatGPT tui README
+# nekot tui README
 
-A terminal util for chatting with LLMs
+A terminal util for chatting with LLMs. Shout out to BalanceBalls for the name!
 
 ## Installation
 
@@ -11,15 +11,15 @@ Set up your [api key](https://platform.openai.com/api-keys)
 ```bash
 export OPENAI_API_KEY="some-key" # you would want to export this in your .zshrc
 brew tap tearingitup786/tearingitup786
-brew install chatgpt-tui
-chatgpt-tui
+brew install nekot 
+nekot
 ```
 
 To get access to the release candidates, install command:
 
 ```bash
-brew install rc-chatgpt-tui
-rc-chatgpt-tui
+brew install rc-nekot
+rc-nekot
 ```
 
 ## Config

--- a/clients/openai.go
+++ b/clients/openai.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/tearingItUp786/chatgpt-tui/util"
+	"github.com/tearingItUp786/nekot/util"
 )
 
 type OpenAiClient struct {

--- a/components/models-list.go
+++ b/components/models-list.go
@@ -8,7 +8,7 @@ import (
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/tearingItUp786/chatgpt-tui/util"
+	"github.com/tearingItUp786/nekot/util"
 )
 
 type ModelsList struct {

--- a/components/sessions-list.go
+++ b/components/sessions-list.go
@@ -9,7 +9,7 @@ import (
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/tearingItUp786/chatgpt-tui/util"
+	"github.com/tearingItUp786/nekot/util"
 )
 
 var (

--- a/components/text-selector.go
+++ b/components/text-selector.go
@@ -8,7 +8,7 @@ import (
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/tearingItUp786/chatgpt-tui/util"
+	"github.com/tearingItUp786/nekot/util"
 )
 
 const (

--- a/config/config-handler.go
+++ b/config/config-handler.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"regexp"
 
-	"github.com/tearingItUp786/chatgpt-tui/util"
+	"github.com/tearingItUp786/nekot/util"
 )
 
 // Define a type for your context key to avoid collisions with other context keys

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tearingItUp786/chatgpt-tui
+module github.com/tearingItUp786/nekot
 
 go 1.22.1
 

--- a/main.go
+++ b/main.go
@@ -11,10 +11,10 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/joho/godotenv"
-	"github.com/tearingItUp786/chatgpt-tui/config"
-	"github.com/tearingItUp786/chatgpt-tui/migrations"
-	"github.com/tearingItUp786/chatgpt-tui/util"
-	"github.com/tearingItUp786/chatgpt-tui/views"
+	"github.com/tearingItUp786/nekot/config"
+	"github.com/tearingItUp786/nekot/migrations"
+	"github.com/tearingItUp786/nekot/util"
+	"github.com/tearingItUp786/nekot/views"
 )
 
 var purgeCache bool

--- a/panes/chat-pane.go
+++ b/panes/chat-pane.go
@@ -8,11 +8,11 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/muesli/reflow/wrap"
-	"github.com/tearingItUp786/chatgpt-tui/clients"
-	"github.com/tearingItUp786/chatgpt-tui/components"
-	"github.com/tearingItUp786/chatgpt-tui/config"
-	"github.com/tearingItUp786/chatgpt-tui/sessions"
-	"github.com/tearingItUp786/chatgpt-tui/util"
+	"github.com/tearingItUp786/nekot/clients"
+	"github.com/tearingItUp786/nekot/components"
+	"github.com/tearingItUp786/nekot/config"
+	"github.com/tearingItUp786/nekot/sessions"
+	"github.com/tearingItUp786/nekot/util"
 )
 
 type displayMode int

--- a/panes/info-pane.go
+++ b/panes/info-pane.go
@@ -9,9 +9,9 @@ import (
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/tearingItUp786/chatgpt-tui/config"
-	"github.com/tearingItUp786/chatgpt-tui/sessions"
-	"github.com/tearingItUp786/chatgpt-tui/util"
+	"github.com/tearingItUp786/nekot/config"
+	"github.com/tearingItUp786/nekot/sessions"
+	"github.com/tearingItUp786/nekot/util"
 )
 
 const notificationDisplayDurationSec = 2

--- a/panes/prompt-pane.go
+++ b/panes/prompt-pane.go
@@ -11,8 +11,8 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/tearingItUp786/chatgpt-tui/config"
-	"github.com/tearingItUp786/chatgpt-tui/util"
+	"github.com/tearingItUp786/nekot/config"
+	"github.com/tearingItUp786/nekot/util"
 )
 
 const ResponseWaitingMsg = "> Please wait ..."

--- a/panes/sessions-pane.go
+++ b/panes/sessions-pane.go
@@ -12,11 +12,11 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/tearingItUp786/chatgpt-tui/components"
-	"github.com/tearingItUp786/chatgpt-tui/config"
-	"github.com/tearingItUp786/chatgpt-tui/sessions"
-	"github.com/tearingItUp786/chatgpt-tui/user"
-	"github.com/tearingItUp786/chatgpt-tui/util"
+	"github.com/tearingItUp786/nekot/components"
+	"github.com/tearingItUp786/nekot/config"
+	"github.com/tearingItUp786/nekot/sessions"
+	"github.com/tearingItUp786/nekot/user"
+	"github.com/tearingItUp786/nekot/util"
 )
 
 const NoTargetSession = -1

--- a/panes/settings-pane.go
+++ b/panes/settings-pane.go
@@ -12,11 +12,11 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/tearingItUp786/chatgpt-tui/clients"
-	"github.com/tearingItUp786/chatgpt-tui/components"
-	"github.com/tearingItUp786/chatgpt-tui/config"
-	"github.com/tearingItUp786/chatgpt-tui/settings"
-	"github.com/tearingItUp786/chatgpt-tui/util"
+	"github.com/tearingItUp786/nekot/clients"
+	"github.com/tearingItUp786/nekot/components"
+	"github.com/tearingItUp786/nekot/config"
+	"github.com/tearingItUp786/nekot/settings"
+	"github.com/tearingItUp786/nekot/util"
 )
 
 const (

--- a/sessions/events.go
+++ b/sessions/events.go
@@ -2,7 +2,7 @@ package sessions
 
 import (
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/tearingItUp786/chatgpt-tui/util"
+	"github.com/tearingItUp786/nekot/util"
 )
 
 type LoadDataFromDB struct {

--- a/sessions/orchestrator.go
+++ b/sessions/orchestrator.go
@@ -8,11 +8,11 @@ import (
 
 	"github.com/atotto/clipboard"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/tearingItUp786/chatgpt-tui/clients"
-	"github.com/tearingItUp786/chatgpt-tui/config"
-	"github.com/tearingItUp786/chatgpt-tui/settings"
-	"github.com/tearingItUp786/chatgpt-tui/user"
-	"github.com/tearingItUp786/chatgpt-tui/util"
+	"github.com/tearingItUp786/nekot/clients"
+	"github.com/tearingItUp786/nekot/config"
+	"github.com/tearingItUp786/nekot/settings"
+	"github.com/tearingItUp786/nekot/user"
+	"github.com/tearingItUp786/nekot/util"
 	"golang.org/x/net/context"
 )
 

--- a/sessions/sessions-db.go
+++ b/sessions/sessions-db.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 
-	"github.com/tearingItUp786/chatgpt-tui/util"
+	"github.com/tearingItUp786/nekot/util"
 )
 
 type Session struct {

--- a/settings/settings-db.go
+++ b/settings/settings-db.go
@@ -11,9 +11,9 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/tearingItUp786/chatgpt-tui/clients"
-	"github.com/tearingItUp786/chatgpt-tui/config"
-	"github.com/tearingItUp786/chatgpt-tui/util"
+	"github.com/tearingItUp786/nekot/clients"
+	"github.com/tearingItUp786/nekot/config"
+	"github.com/tearingItUp786/nekot/util"
 )
 
 // const ModelsCacheTtl = time.Second * 5

--- a/settings/settings-events.go
+++ b/settings/settings-events.go
@@ -2,7 +2,7 @@ package settings
 
 import (
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/tearingItUp786/chatgpt-tui/util"
+	"github.com/tearingItUp786/nekot/util"
 )
 
 type UpdateSettingsEvent struct {

--- a/util/db.go
+++ b/util/db.go
@@ -8,10 +8,22 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/pressly/goose/v3"
 )
+
+func GetAppDirName() string {
+	exePath, err := os.Executable()
+	if err != nil {
+		return ".chatgpt-tui" // fallback
+	}
+	binaryName := filepath.Base(exePath)
+	binaryName = strings.TrimSuffix(binaryName, filepath.Ext(binaryName)) // remove .exe if present
+
+	return "." + binaryName
+}
 
 func GetAppDataPath() (string, error) {
 	// Get the user's home directory
@@ -21,7 +33,7 @@ func GetAppDataPath() (string, error) {
 	}
 
 	// Define the application-specific part of the path
-	appDirName := ".chatgpt-tui"
+	appDirName := GetAppDirName()
 
 	// Combine them to form the full path
 	fullPath := filepath.Join(homeDir, appDirName)

--- a/views/main-view.go
+++ b/views/main-view.go
@@ -13,10 +13,10 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"golang.org/x/term"
 
-	"github.com/tearingItUp786/chatgpt-tui/clients"
-	"github.com/tearingItUp786/chatgpt-tui/panes"
-	"github.com/tearingItUp786/chatgpt-tui/sessions"
-	"github.com/tearingItUp786/chatgpt-tui/util"
+	"github.com/tearingItUp786/nekot/clients"
+	"github.com/tearingItUp786/nekot/panes"
+	"github.com/tearingItUp786/nekot/sessions"
+	"github.com/tearingItUp786/nekot/util"
 )
 
 const pulsarIntervalMs = 300


### PR DESCRIPTION
## Description

It's time for a rename. We'll start with the internal go modules and module paths and then after that's all good to go, we can rename the repo accordingly. 

- rename go modules to `nekot`
- update release commands to publish `rc-nekot` and `nekot` respectively
- update `readme.md` to have a section on legacy `chatgpt-tui` and 

#16 

